### PR TITLE
adds missing sys import that causes crash in docker containers

### DIFF
--- a/bin/etcdreg
+++ b/bin/etcdreg
@@ -1,6 +1,6 @@
 #!/bin/python
 
-import etcdreg
+import sys,etcdreg
 
 if __name__ == "__main__":
    etcdreg.main(sys.argv[1:])


### PR DESCRIPTION
In docker containers with multiple non-default ports exposed, the service crashes with lack of sys import.
Adding the import in the beginning seems to solve the issue. Not certain if that's 'the python way'.

``` shell
root@7e85e266e3f4:/# cat /etc/service/etcdreg/run
#!/bin/bash
exec etcdreg -i $PUBLIC_IP -p 80,81,8080,8081 --ttl 5 -s $SERVICE_NAME -e $ETCD_IP:2379
root@7e85e266e3f4:/# ./etc/service/etcdreg/run
Traceback (most recent call last):
  File "/usr/bin/etcdreg", line 6, in <module>
    etcdreg.main(sys.argv[1:])
NameError: name 'sys' is not defined
```
